### PR TITLE
cmake: add DISABLE_CPU_OPTIMIZATION option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 cmake_minimum_required(VERSION 3.0)
 project(LPCNet C)
 
+option(DISABLE_CPU_OPTIMIZATION "Disable CPU optimization discovery." OFF)
 option(AVX2 "Enable AVX2 CPU optimizations." OFF)
 option(AVX "Enable AVX CPU optimizations." OFF)
 option(NEON "Enable NEON CPU optimizations for RPi." OFF)
@@ -33,27 +34,29 @@ endif("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
 set(CMAKE_C_FLAGS "-Wall -W -Wextra -Wno-unused-function -O3 -g -I. -MD ${CMAKE_C_FLAGS} -DENABLE_ASSERTIONS")
 
 # Detection of available CPU optimizations
-if(UNIX AND NOT APPLE)
-    message(STATUS "Looking for available CPU optimizations on Linux/BSD system...")
-    execute_process(COMMAND grep -c "avx2" /proc/cpuinfo
-        OUTPUT_VARIABLE AVX2)
-    execute_process(COMMAND grep -c "avx " /proc/cpuinfo
-        OUTPUT_VARIABLE AVX)
-    execute_process(COMMAND grep -c "neon" /proc/cpuinfo
-        OUTPUT_VARIABLE NEON)
-elseif(APPLE)
-    # Under OSX we need to look through a few sysctl entries to determine what our CPU supports.
-    message(STATUS "Looking for available CPU optimizations on an OSX system...")
-    execute_process(COMMAND sysctl -a COMMAND grep machdep.cpu.leaf7_features COMMAND grep -c AVX2
-        OUTPUT_VARIABLE AVX2)
-    execute_process(COMMAND sysctl -a COMMAND grep machdep.cpu.features COMMAND grep -c AVX
-        OUTPUT_VARIABLE AVX)
-elseif(WIN32)
-    message(STATUS "No detection capability on Windows, assuming AVX is available.")
-    set(AVX TRUE)
-else()
-    message(STATUS "System is not *nix, processor specific optimizations cannot be determined.")
-    message("   You can try setting them manually, e.g.: -DAVX2=1 or -DAVX=1 or -DNEON=1")
+if(NOT DISABLE_CPU_OPTIMIZATION)
+    if(UNIX AND NOT APPLE)
+        message(STATUS "Looking for available CPU optimizations on Linux/BSD system...")
+        execute_process(COMMAND grep -c "avx2" /proc/cpuinfo
+            OUTPUT_VARIABLE AVX2)
+        execute_process(COMMAND grep -c "avx " /proc/cpuinfo
+            OUTPUT_VARIABLE AVX)
+        execute_process(COMMAND grep -c "neon" /proc/cpuinfo
+            OUTPUT_VARIABLE NEON)
+    elseif(APPLE)
+        # Under OSX we need to look through a few sysctl entries to determine what our CPU supports.
+        message(STATUS "Looking for available CPU optimizations on an OSX system...")
+        execute_process(COMMAND sysctl -a COMMAND grep machdep.cpu.leaf7_features COMMAND grep -c AVX2
+            OUTPUT_VARIABLE AVX2)
+        execute_process(COMMAND sysctl -a COMMAND grep machdep.cpu.features COMMAND grep -c AVX
+            OUTPUT_VARIABLE AVX)
+    elseif(WIN32)
+        message(STATUS "No detection capability on Windows, assuming AVX is available.")
+        set(AVX TRUE)
+    else()
+        message(STATUS "System is not *nix, processor specific optimizations cannot be determined.")
+        message("   You can try setting them manually, e.g.: -DAVX2=1 or -DAVX=1 or -DNEON=1")
+    endif()
 endif()
 
 if(${AVX2} OR ${AVX2} GREATER 0)


### PR DESCRIPTION
add new option to disable cpu flags auto-discovery.
needed by binary package manager because not all architecture has avx.