### PR TITLE
Add CMake rule to ensure LPCNet is built with the correct OSX libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@
 #          flags manually on cmd line
 #       2/ Should we standardise on just AVX?  As machine we run on
 #          may be different to machine we build on
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
+
 cmake_minimum_required(VERSION 3.0)
 project(LPCNet C)
 


### PR DESCRIPTION
Looks like the latest OSX SDK [adds a ____chkstk_darwin symbol reference libraries/executables built for 10.14 and later](https://github.com/Homebrew/homebrew-core/pull/46983#issuecomment-556906673). This results in crashes on older OSX releases when using a binary built on a newer version ([example](https://slexy.org/view/s21ec1R3gg)). 

Anyway, forcing CMAKE_OSX_DEPLOYMENT_TARGET like what's done on FreeDV resolves the issue.