### PR TITLE
Update vec_avx.h

### DIFF
--- a/src/vec_avx.h
+++ b/src/vec_avx.h
@@ -79,7 +79,7 @@ static __m128 exp4_approx(__m128 X)
    Y = _mm_castsi128_ps(_mm_and_si128(mask, _mm_add_epi32(I, _mm_castps_si128(Y))));
    return Y;
 }
-static __m256 exp8_approx(__m256 X)
+static inline __m256 exp8_approx(__m256 X)
 {
    __m256 Y;
    __m128 Xhi, Xlo, Yhi, Ylo;


### PR DESCRIPTION
Cater for quirk of AMD FX-6100 processor partial AVX support by inlining exp8_approx()
https://github.com/drowe67/LPCNet/issues/32
