### PR TITLE
Mac universal binary support for LPCNet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ mark_as_advanced(CLEAR
 )
 
 # Build universal ARM64 and x86_64 binaries on Mac.
+if(BUILD_OSX_UNIVERSAL)
 set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
+endif(BUILD_OSX_UNIVERSAL)
 
 #
 # Prevent in-source builds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ mark_as_advanced(CLEAR
 )
 
 # Build universal ARM64 and x86_64 binaries on Mac.
-set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64e")
+set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
 
 #
 # Prevent in-source builds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ mark_as_advanced(CLEAR
     CMAKE_INSTALL_LIBDIR
 )
 
+# Build universal ARM64 and x86_64 binaries on Mac.
+set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64e")
+
 #
 # Prevent in-source builds
 # If an in-source build is attempted, you will still need to clean up a few


### PR DESCRIPTION
As mentioned in https://github.com/drowe67/codec2/pull/154, this is to add ARM/x86_64 universal builds to LPCNet to support Apple Silicon devices. Let me know if you have any questions!