### PR TITLE
Add Git hash to Debian package filename

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,16 @@ else()
     set(CPACK_PACKAGE_VERSION_PATCH 0)
 endif()
 
+# Return the date (yyyy-mm-dd)
+macro(DATE RESULT)
+  execute_process(COMMAND "date" "+%Y%m%d" OUTPUT_VARIABLE ${RESULT})
+endmacro()
+DATE(DATE_RESULT)
+string(REGEX REPLACE "\n$" "" DATE_RESULT "${DATE_RESULT}")
+message(STATUS "Compilation date = XX${DATE_RESULT}XX")
+
+set(CPACK_PACKAGE_VERSION_PATCH "${CPACK_PACKAGE_VERSION_PATCH}-${DATE_RESULT}-${FREEDV_HASH}")
+
 if(UNIX AND NOT APPLE)
     # Linux packaging
     SET(CPACK_GENERATOR "DEB")


### PR DESCRIPTION
This is mainly to make the filenames consistent across all three projects (freedv-gui, codec2, LPCNet).