### PR TITLE
Clean up warnings encountered during Windows and macOS builds.

### DIFF
--- a/src/lpcnet.c
+++ b/src/lpcnet.c
@@ -146,7 +146,6 @@ void lpcnet_set_pitch_embedding(LPCNetState *lpcnet, int val) {
 
 void lpcnet_synthesize(LPCNetState *lpcnet, short *output, float *features, int N, int mag)
 {
-    static int count = 0;
     int i;
     float condition[FEATURE_DENSE2_OUT_SIZE];
     float lpc[LPC_ORDER];
@@ -264,7 +263,6 @@ void lpcnet_synthesize(LPCNetState *lpcnet, short *output, float *features, int 
             exc_f = ulaw2lin(exc);
             fwrite(&exc_f, sizeof(float), 1, lpcnet->ftest);
             fwrite(&pcm, sizeof(float), 1, lpcnet->ftest);
-            count++;
         }
         output[i] = (int)floor(.5 + pcm);
     }

--- a/src/lpcnet_enc.c
+++ b/src/lpcnet_enc.c
@@ -147,7 +147,6 @@ int main(int argc, char **argv) {
     fprintf(stderr, "\n");
 
     char frame[lpcnet_bits_per_frame(lf)];
-    int f=0;
     int bits_written=0;
     short pcm[lpcnet_samples_per_frame(lf)];
 
@@ -160,7 +159,6 @@ int main(int argc, char **argv) {
 
         fflush(stdin);
         fflush(stdout);
-        f++;
     }
 
     lpcnet_freedv_destroy(lf);


### PR DESCRIPTION
This PR cleans up the following warnings:

```
/home/mooneer/freedv-gui/build_win_x86_64/LPCNet_src/src/lpcnet.c:149:16: warning: variable 'count' set but not used [-Wunused-but-set-variable]
    static int count = 0;
               ^
1 warning generated.

/home/mooneer/freedv-gui/build_win_x86_64/LPCNet_src/src/lpcnet_enc.c:150:9: warning: variable 'f' set but not used [-Wunused-but-set-variable]
    int f=0;
        ^
1 warning generated.
```

The following warnings are still appearing as of this PR. I'm not sure how to fix those yet (if we can), so feedback is appreciated:

```
/Users/mooneer/devel/LPCNet/src/pitch.c:229:37: warning: performing pointer subtraction with a null pointer has undefined behavior [-Wnull-pointer-subtraction]
   celt_assert((((unsigned char *)_x-(unsigned char *)NULL)&3)==0);
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/mooneer/devel/LPCNet/src/arch.h:63:34: note: expanded from macro 'celt_assert'
#define celt_assert(cond) {if (!(cond)) {celt_fatal("assertion failed: " #cond);}}
                                 ^~~~
1 warning generated
/Users/mooneer/devel/LPCNet/src/from_codec2/sine.c:406:57: warning: unused parameter 'W' [-Wunused-parameter]
void estimate_amplitudes(MODEL *model, COMP Sw[], float W[], int est_phase)
                                                        ^
1 warning generated.
/Users/mooneer/devel/LPCNet/src/from_codec2/nlp.c:255:10: warning: unused parameter 'Sw' [-Wunused-parameter]
  COMP   Sw[],                  /* Freq domain version of Sn[]                        */
         ^
/Users/mooneer/devel/LPCNet/src/from_codec2/nlp.c:256:10: warning: unused parameter 'W' [-Wunused-parameter]
  float  W[],                   /* Freq domain window                                 */
         ^
/Users/mooneer/devel/LPCNet/src/from_codec2/nlp.c:431:10: warning: unused parameter 'pmin' [-Wunused-parameter]
                                 int pmin, int pmax, float gmax, int gmax_bin,
                                     ^
3 warnings generated.
```