### PR TITLE
Check CMAKE_OSX_ARCHITECTURES and only define relevant optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 #          flags manually on cmd line
 #       2/ Should we standardise on just AVX?  As machine we run on
 #          may be different to machine we build on
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.9" CACHE STRING "Minimum OS X deployment version")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.5" CACHE STRING "Minimum OS X deployment version")
 
 cmake_minimum_required(VERSION 3.0)
 
@@ -26,10 +26,11 @@ mark_as_advanced(CLEAR
     CMAKE_INSTALL_LIBDIR
 )
 
-# Build universal ARM64 and x86_64 binaries on Mac.
-if(BUILD_OSX_UNIVERSAL)
+# Build universal ARM64 and x86_64 binaries on Mac if not explicitly
+# told otherwise (i.e. if building for PPC).
+if(BUILD_OSX_UNIVERSAL AND NOT CMAKE_OSX_ARCHITECTURES)
 set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
-endif(BUILD_OSX_UNIVERSAL)
+endif(BUILD_OSX_UNIVERSAL AND NOT CMAKE_OSX_ARCHITECTURES)
 
 #
 # Prevent in-source builds
@@ -104,11 +105,17 @@ if(NOT DISABLE_CPU_OPTIMIZATION)
             OUTPUT_VARIABLE NEON_PRESENT)
     elseif(APPLE)
         if(BUILD_OSX_UNIVERSAL)
+            message(STATUS "Performing universal macOS build using architectures ${CMAKE_OSX_ARCHITECTURES}")
+
             # Presume AVX and SSE are enabled on the x86 side. (AVX2 is not guaranteed depending
             # on model.) The ARM side will auto-enable NEON optimizations by virtue of being aarch64.
-            set(AVX_PRESENT TRUE)
-            set(SSE_PRESENT TRUE)
-            set(NEON_PRESENT TRUE)
+            if(CMAKE_OSX_ARCHITECTURES MATCHES "[xX]86")
+                set(AVX_PRESENT TRUE)
+                set(SSE_PRESENT TRUE)
+            endif(CMAKE_OSX_ARCHITECTURES MATCHES "[xX]86")
+            if(CMAKE_OSX_ARCHITECTURES MATCHES "[Aa][Rr][Mm]")
+                set(NEON_PRESENT TRUE)
+            endif(CMAKE_OSX_ARCHITECTURES MATCHES "[Aa][Rr][Mm]")
         else()
             # Under OSX we need to look through a few sysctl entries to determine what our CPU supports.
             message(STATUS "Looking for available CPU optimizations on an OSX system...")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,7 +128,8 @@ if(NOT DISABLE_CPU_OPTIMIZATION)
                 
             # Unlike with the above, NEON *is* guaranteed if on ARM as there were never any ARM32 Macs 
             # available. We don't need any specific compiler flags for this, though.
-            set(NEON_PRESENT TRUE)
+            execute_process(COMMAND sysctl -a COMMAND grep -c hw.optional.neon
+                OUTPUT_VARIABLE NEON_PRESENT)
         endif(BUILD_OSX_UNIVERSAL)
     elseif(WIN32)
         message(STATUS "No detection capability on Windows, assuming AVX is available.")
@@ -165,7 +166,7 @@ elseif(${SSE} AND (${SSE_PRESENT} OR ${SSE_PRESENT} GREATER 0))
 # AVX and AVX2 machines will also match on SSE
     message(STATUS "sse processor flags found or enabled.")
     set(LPCNET_C_PROC_FLAGS -msse4.1)
-elseif(${NEON} AND (${NEON_PRESENT} OR ${NEON_PRESENT} GREATER 0))
+elseif(${NEON} AND (${NEON_PRESENT} OR ${NEON_PRESENT} GREATER 0) AND NOT APPLE)
     # RPi / ARM 32bit
     message(STATUS "neon processor flags found or enabled.")
     set(LPCNET_C_PROC_FLAGS -mfpu=neon -march=armv8-a -mtune=cortex-a53)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,16 +26,27 @@ mark_as_advanced(CLEAR
     CMAKE_INSTALL_LIBDIR
 )
 
-# Build universal ARM64 and x86_64 binaries on Mac if not explicitly
-# told otherwise (i.e. if building for PPC).
-if(CMAKE_OSX_ARCHITECTURES)
-    # Assume universal build if architectures are being overridden.
-    set(BUILD_OSX_UNIVERSAL 1)
-endif(CMAKE_OSX_ARCHITECTURES)
-
 if(BUILD_OSX_UNIVERSAL AND NOT CMAKE_OSX_ARCHITECTURES)
 set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
 endif(BUILD_OSX_UNIVERSAL AND NOT CMAKE_OSX_ARCHITECTURES)
+
+if(APPLE)
+    function(can_enable_for_architecture ARCH RET)
+        if(BUILD_OSX_UNIVERSAL)
+            if(CMAKE_OSX_ARCHITECTURES MATCHES ${ARCH})
+                set(${RET} TRUE PARENT_SCOPE)
+            else()
+                set(${RET} FALSE PARENT_SCOPE)
+            endif()
+        else()
+            if(CMAKE_SYSTEM_PROCESSOR MATCHES ${ARCH})
+                set(${RET} TRUE PARENT_SCOPE)
+            else()
+                set(${RET} FALSE PARENT_SCOPE)
+            endif()
+        endif()
+    endfunction()
+endif(APPLE)
 
 #
 # Prevent in-source builds
@@ -114,27 +125,28 @@ if(NOT DISABLE_CPU_OPTIMIZATION)
 
             # Presume AVX and SSE are enabled on the x86 side. (AVX2 is not guaranteed depending
             # on model.) The ARM side will auto-enable NEON optimizations by virtue of being aarch64.
-            if(CMAKE_OSX_ARCHITECTURES MATCHES "[xX]86")
+            can_enable_for_architecture("[xX]86" IS_X86)
+            if(IS_X86)
                 set(AVX_PRESENT TRUE)
                 set(SSE_PRESENT TRUE)
-            endif(CMAKE_OSX_ARCHITECTURES MATCHES "[xX]86")
-            if(CMAKE_OSX_ARCHITECTURES MATCHES "[Aa][Rr][Mm]")
-                set(NEON_PRESENT TRUE)
-            endif(CMAKE_OSX_ARCHITECTURES MATCHES "[Aa][Rr][Mm]")
+            endif()
+            can_enable_for_architecture("[Aa][Rr][Mm]" NEON_PRESENT)
         else()
             # Under OSX we need to look through a few sysctl entries to determine what our CPU supports.
             message(STATUS "Looking for available CPU optimizations on an OSX system...")
-            execute_process(COMMAND sysctl -a COMMAND grep machdep.cpu.leaf7_features COMMAND grep -c AVX2
-                OUTPUT_VARIABLE AVX2_PRESENT)
-            execute_process(COMMAND sysctl -a COMMAND grep machdep.cpu.features COMMAND grep -c AVX
-                OUTPUT_VARIABLE AVX_PRESENT)
-            execute_process(COMMAND sysctl -a COMMAND grep machdep.cpu.features COMMAND grep -c SSE4.1
-                OUTPUT_VARIABLE SSE_PRESENT)
+            can_enable_for_architecture("[xX]86" IS_X86)
+            if(IS_X86)
+                execute_process(COMMAND sysctl -a COMMAND grep machdep.cpu.leaf7_features COMMAND grep -c AVX2
+                    OUTPUT_VARIABLE AVX2_PRESENT)
+                execute_process(COMMAND sysctl -a COMMAND grep machdep.cpu.features COMMAND grep -c AVX
+                    OUTPUT_VARIABLE AVX_PRESENT)
+                execute_process(COMMAND sysctl -a COMMAND grep machdep.cpu.features COMMAND grep -c SSE4.1
+                    OUTPUT_VARIABLE SSE_PRESENT)
+            endif()
                 
             # Unlike with the above, NEON *is* guaranteed if on ARM as there were never any ARM32 Macs 
             # available. We don't need any specific compiler flags for this, though.
-            execute_process(COMMAND sysctl -a COMMAND grep -c hw.optional.neon
-                OUTPUT_VARIABLE NEON_PRESENT)
+            can_enable_for_architecture("[Aa][Rr][Mm]" NEON_PRESENT)
         endif(BUILD_OSX_UNIVERSAL)
     elseif(WIN32)
         message(STATUS "No detection capability on Windows, assuming AVX is available.")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ mark_as_advanced(CLEAR
 
 # Build universal ARM64 and x86_64 binaries on Mac if not explicitly
 # told otherwise (i.e. if building for PPC).
+if(CMAKE_OSX_ARCHITECTURES)
+    # Assume universal build if architectures are being overridden.
+    set(BUILD_OSX_UNIVERSAL 1)
+endif(CMAKE_OSX_ARCHITECTURES)
+
 if(BUILD_OSX_UNIVERSAL AND NOT CMAKE_OSX_ARCHITECTURES)
 set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64")
 endif(BUILD_OSX_UNIVERSAL AND NOT CMAKE_OSX_ARCHITECTURES)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Experimental version of LPCNet that has been used to develop FreeDV 2020 - a HF radio Digital Voice mode for over the air experimentation with Neural Net speech coding.  Possibly the first use of Neural Net speech coding in real world operation.
 
+*Note: while this should be able to compile on any architecutre with a modern C compiler, this package only supports Intel and ARM architectures. Usage on others will likely exhibit extremely low performance and possibly have bugs.*
+
 ## Quickstart
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Experimental version of LPCNet that has been used to develop FreeDV 2020 - a HF radio Digital Voice mode for over the air experimentation with Neural Net speech coding.  Possibly the first use of Neural Net speech coding in real world operation.
 
-*Note: while this should be able to compile on any architecutre with a modern C compiler, this package only supports Intel and ARM architectures. Usage on others will likely exhibit extremely low performance and possibly have bugs.*
+*Note: while this should be able to compile on any architecture with a modern C compiler, this package only supports Intel and ARM architectures. Usage on others will likely exhibit extremely low performance and possibly have bugs.*
 
 ## Quickstart
 


### PR DESCRIPTION
Per previous PLT discussion, this PR reimplements #57 in a manner that should have lower impact:

* The lowest supported macOS release is set to 10.5 unconditionally. CMake/Apple Clang from personal experience will use the minimum supported version of the SDK for each architecture provided in `CMAKE_OSX_ARCHITECTURES`.
* `CMAKE_OSX_ARCHITECTURES` is set to x86_64 and arm64 unless specifically overridden at the command line (i.e. `cmake -DCMAKE_OSX_ARCHITECTURES=ppc\;ppc64 ..`)
* `*_PRESENT` is only enabled for the relevant architectures based on the contents of `CMAKE_OSX_ARCHITECTURES`.
* The README file has been updated to clarify that only x86 and ARM are officially supported.